### PR TITLE
(doc) Fix typo in YARD param

### DIFF
--- a/lib/bake/context.rb
+++ b/lib/bake/context.rb
@@ -147,7 +147,7 @@ module Bake
 			end
 		end
 		
-		# @param scope [Array<String>] the path for the scope.
+		# @param path [Array<String>] the path for the scope.
 		def base_for(path)
 			base = nil
 			


### PR DESCRIPTION
Found when installing.

```
Building YARD (yri) index for bake-0.7.0...
lib/bake/context.rb:150: [UnknownParam] @param tag has unknown parameter name: scope
```