### PR TITLE
Add dependency bigdecimal

### DIFF
--- a/bake.gemspec
+++ b/bake.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 2.7.6b"
 	
 	spec.add_dependency "samovar", "~> 2.1"
+	spec.add_dependency "bigdecimal"
 	
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"


### PR DESCRIPTION
Avoid this Ruby warning:

    /gems/3.3.0+0/gems/bake-0.18.2/lib/bake/types/decimal.rb:25: warning: bigdecimal will be not
    part of the default gems since Ruby 3.4.0. Add bigdecimal to your gems.rb.
    Also contact author of  to add bigdecimal into its gemspec.