### PR TITLE
Prefer positional arguments before key/value options

### DIFF
--- a/lib/bake/arguments.rb
+++ b/lib/bake/arguments.rb
@@ -44,6 +44,12 @@ module Bake
 					
 					# Extract the trailing arguments:
 					@options[name] = extract_arguments(name, arguments)
+				elsif @ordered.size < @arity
+					_, name = @parameters.shift
+					value = arguments.shift
+
+					# Consume it:
+					@ordered << extract_argument(name, value)
 				elsif /^(?<name>.*?)=(?<value>.*)$/ =~ argument
 					# Consume the argument:
 					arguments.shift
@@ -52,12 +58,6 @@ module Bake
 					
 					# Extract the single argument:
 					@options[name] = extract_argument(name, value)
-				elsif @ordered.size < @arity
-					_, name = @parameters.shift
-					value = arguments.shift
-					
-					# Consume it:
-					@ordered << extract_argument(name, value)
 				else
 					break
 				end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Prefer positional arguments before interpreting `name=value` optional arguments.
+
 ## v0.24.1
 
   - Add agent context.

--- a/test/bake/arguments.rb
+++ b/test/bake/arguments.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "bake/base"
+
+class TestArguments < Bake::Base
+	def positional(url)
+		url
+	end
+	
+	def mixed(url, option: nil)
+		[url, option]
+	end
+end
+
+describe Bake::Arguments do
+	let(:instance) {TestArguments.new}
+	
+	it "prefers positional arguments before key/value arguments" do
+		recipe = instance.recipe_for(:positional)
+		arguments, options = recipe.prepare(["https://foo?x=y"])
+		
+		expect(arguments).to be == ["https://foo?x=y"]
+		expect(options).to be == {}
+	end
+	
+	it "extracts key/value arguments after positional arguments" do
+		recipe = instance.recipe_for(:mixed)
+		arguments, options = recipe.prepare(["https://foo?x=y", "option=value"])
+		
+		expect(arguments).to be == ["https://foo?x=y"]
+		expect(options).to be == {option: "value"}
+	end
+end


### PR DESCRIPTION
## Summary
- Consume required positional arguments before interpreting `name=value` optional arguments.
- Add regression coverage for URLs like `https://foo?x=y` used as positional arguments.
- Keep `name=value` option extraction after required positionals are filled.

## Tests
- `source /opt/homebrew/share/chruby/chruby.sh && chruby 3.4 && bundle exec sus test/bake/arguments.rb`
- `source /opt/homebrew/share/chruby/chruby.sh && chruby 3.4 && bundle exec sus`